### PR TITLE
Allow specifying parameter names as single strings in Python

### DIFF
--- a/src/omuse/community/iemic/interface.cc
+++ b/src/omuse/community/iemic/interface.cc
@@ -444,7 +444,7 @@ get_parameter_name(char *param_set_name, char *param_name, int i, char **name)
     return -1;
 }
 
-int32_t get_parameter_type(char *param_set_name, char *param_name, char **name)
+int32_t _get_parameter_type(char *param_set_name, char *param_name, char **name)
 {
     try {
         resultString = parameter_sets.at(param_set_name).get_param_type(param_name);
@@ -460,7 +460,7 @@ int32_t get_parameter_type(char *param_set_name, char *param_name, char **name)
 }
 
 int32_t
-get_bool_parameter(char *param_set_name, char *param_name, bool *result)
+_get_bool_parameter(char *param_set_name, char *param_name, bool *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -476,7 +476,7 @@ get_bool_parameter(char *param_set_name, char *param_name, bool *result)
 }
 
 int32_t
-set_bool_parameter(char *param_set_name, char *param_name, bool val)
+_set_bool_parameter(char *param_set_name, char *param_name, bool val)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -492,7 +492,7 @@ set_bool_parameter(char *param_set_name, char *param_name, bool val)
 }
 
 int32_t
-get_default_bool_parameter(char *param_set_name, char *param_name, bool *result)
+_get_default_bool_parameter(char *param_set_name, char *param_name, bool *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -508,7 +508,7 @@ get_default_bool_parameter(char *param_set_name, char *param_name, bool *result)
 }
 
 int32_t
-get_char_parameter(char *param_set_name, char *param_name, char *result)
+_get_char_parameter(char *param_set_name, char *param_name, char *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -524,7 +524,7 @@ get_char_parameter(char *param_set_name, char *param_name, char *result)
 }
 
 int32_t
-set_char_parameter(char *param_set_name, char *param_name, char val)
+_set_char_parameter(char *param_set_name, char *param_name, char val)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -540,7 +540,7 @@ set_char_parameter(char *param_set_name, char *param_name, char val)
 }
 
 int32_t
-get_default_char_parameter(char *param_set_name, char *param_name, char *result)
+_get_default_char_parameter(char *param_set_name, char *param_name, char *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -556,7 +556,7 @@ get_default_char_parameter(char *param_set_name, char *param_name, char *result)
 }
 
 int32_t
-get_double_parameter(char *param_set_name, char *param_name, double *result)
+_get_double_parameter(char *param_set_name, char *param_name, double *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -572,7 +572,7 @@ get_double_parameter(char *param_set_name, char *param_name, double *result)
 }
 
 int32_t
-set_double_parameter(char *param_set_name, char *param_name, double val)
+_set_double_parameter(char *param_set_name, char *param_name, double val)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -588,7 +588,7 @@ set_double_parameter(char *param_set_name, char *param_name, double val)
 }
 
 int32_t
-get_default_double_parameter(char *param_set_name, char *param_name, double *result)
+_get_default_double_parameter(char *param_set_name, char *param_name, double *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -604,7 +604,7 @@ get_default_double_parameter(char *param_set_name, char *param_name, double *res
 }
 
 int32_t
-get_int_parameter(char *param_set_name, char *param_name, int *result)
+_get_int_parameter(char *param_set_name, char *param_name, int *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -620,7 +620,7 @@ get_int_parameter(char *param_set_name, char *param_name, int *result)
 }
 
 int32_t
-set_int_parameter(char *param_set_name, char *param_name, int val)
+_set_int_parameter(char *param_set_name, char *param_name, int val)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -636,7 +636,7 @@ set_int_parameter(char *param_set_name, char *param_name, int val)
 }
 
 int32_t
-get_default_int_parameter(char *param_set_name, char *param_name, int *result)
+_get_default_int_parameter(char *param_set_name, char *param_name, int *result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -652,7 +652,7 @@ get_default_int_parameter(char *param_set_name, char *param_name, int *result)
 }
 
 int32_t
-get_string_parameter(char *param_set_name, char *param_name, char **result)
+_get_string_parameter(char *param_set_name, char *param_name, char **result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -669,7 +669,7 @@ get_string_parameter(char *param_set_name, char *param_name, char **result)
 }
 
 int32_t
-set_string_parameter(char *param_set_name, char *param_name, char *val)
+_set_string_parameter(char *param_set_name, char *param_name, char *val)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);
@@ -685,7 +685,7 @@ set_string_parameter(char *param_set_name, char *param_name, char *val)
 }
 
 int32_t
-get_default_string_parameter(char *param_set_name, char *param_name, char **result)
+_get_default_string_parameter(char *param_set_name, char *param_name, char **result)
 {
     try {
         auto& paramset = parameter_sets.at(param_set_name);

--- a/src/omuse/community/iemic/interface.hpp
+++ b/src/omuse/community/iemic/interface.hpp
@@ -28,25 +28,25 @@ int32_t get_num_parameter_sets(int *_num);
 int32_t get_parameter_set_name(int i, char **name);
 int32_t get_num_parameters(char *param_set_name, char *param_name, int *_num);
 int32_t get_parameter_name(char *param_set_name, char *param_name, int i, char **name);
-int32_t get_parameter_type(char *param_set_name, char *param_name, char **name);
+int32_t _get_parameter_type(char *param_set_name, char *param_name, char **name);
 
-int32_t get_bool_parameter(char *param_set_name, char *param_name, bool *result);
-int32_t set_bool_parameter(char *param_set_name, char *param_name, bool val);
-int32_t get_default_bool_parameter(char *param_set_name, char *param_name, bool *result);
+int32_t _get_bool_parameter(char *param_set_name, char *param_name, bool *result);
+int32_t _set_bool_parameter(char *param_set_name, char *param_name, bool val);
+int32_t _get_default_bool_parameter(char *param_set_name, char *param_name, bool *result);
 
-int32_t get_char_parameter(char *param_set_name, char *param_name, char *result);
-int32_t set_char_parameter(char *param_set_name, char *param_name, char val);
-int32_t get_default_char_parameter(char *param_set_name, char *param_name, char *result);
+int32_t _get_char_parameter(char *param_set_name, char *param_name, char *result);
+int32_t _set_char_parameter(char *param_set_name, char *param_name, char val);
+int32_t _get_default_char_parameter(char *param_set_name, char *param_name, char *result);
 
-int32_t get_double_parameter(char *param_set_name, char *param_name, double *result);
-int32_t set_double_parameter(char *param_set_name, char *param_name, double val);
-int32_t get_default_double_parameter(char *param_set_name, char *param_name, double *result);
+int32_t _get_double_parameter(char *param_set_name, char *param_name, double *result);
+int32_t _set_double_parameter(char *param_set_name, char *param_name, double val);
+int32_t _get_default_double_parameter(char *param_set_name, char *param_name, double *result);
 
-int32_t get_int_parameter(char *param_set_name, char *param_name, int *result);
-int32_t set_int_parameter(char *param_set_name, char *param_name, int val);
-int32_t get_default_int_parameter(char *param_set_name, char *param_name, int *result);
+int32_t _get_int_parameter(char *param_set_name, char *param_name, int *result);
+int32_t _set_int_parameter(char *param_set_name, char *param_name, int val);
+int32_t _get_default_int_parameter(char *param_set_name, char *param_name, int *result);
 
-int32_t get_string_parameter(char *param_set_name, char *param_name, char **result);
-int32_t set_string_parameter(char *param_set_name, char *param_name, char *val);
-int32_t get_default_string_parameter(char *param_set_name, char *param_name, char **result);
+int32_t _get_string_parameter(char *param_set_name, char *param_name, char **result);
+int32_t _set_string_parameter(char *param_set_name, char *param_name, char *val);
+int32_t _get_default_string_parameter(char *param_set_name, char *param_name, char **result);
 #endif

--- a/src/omuse/community/iemic/interface.py
+++ b/src/omuse/community/iemic/interface.py
@@ -137,7 +137,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(name="")
 
     def get_parameter_type(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_parameter_type(set_name, param_name)
 
     @remote_function
@@ -145,7 +145,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=False)
 
     def get_bool_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_bool_parameter(set_name, param_name)
 
     @remote_function
@@ -153,7 +153,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns()
 
     def set_bool_parameter(self, param_name, val):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._set_bool_parameter(set_name, param_name, val)
 
     @remote_function
@@ -169,7 +169,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=False)
 
     def get_default_bool_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_default_bool_parameter(set_name, param_name)
 
     #@remote_function
@@ -189,7 +189,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=0.)
 
     def get_double_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_double_parameter(set_name, param_name)
 
     @remote_function
@@ -197,7 +197,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns()
 
     def set_double_parameter(self, param_name, val):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._set_double_parameter(set_name, param_name, val)
 
     @remote_function
@@ -205,7 +205,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=0.)
 
     def get_default_double_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_default_double_parameter(set_name, param_name)
 
     @remote_function
@@ -213,7 +213,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=0)
 
     def get_int_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_int_parameter(set_name, param_name)
 
     @remote_function
@@ -221,7 +221,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns()
 
     def set_int_parameter(self, param_name, val):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._set_int_parameter(set_name, param_name, val)
 
     @remote_function
@@ -229,7 +229,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value=0)
 
     def get_default_int_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_default_int_parameter(set_name, param_name)
 
     @remote_function
@@ -237,7 +237,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value="")
 
     def get_string_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         print(set_name, param_name)
         return self._get_string_parameter(set_name, param_name)
 
@@ -246,7 +246,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns()
 
     def set_string_parameter(self, param_name, val):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._set_string_parameter(set_name, param_name, val)
 
     @remote_function
@@ -254,7 +254,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(value="")
 
     def get_default_string_parameter(self, param_name):
-        set_name, param_name = param_name.split("?", 1)
+        set_name, param_name = param_name.split("->", 1)
         return self._get_default_string_parameter(set_name, param_name)
 
     @remote_function(can_handle_array=True)
@@ -336,21 +336,21 @@ class iemic(InCodeComponentImplementation):
     def _generate_parameter_setter_getters(self, paramSet, sublist, paramName, paramType):
         # define getter (closure or partial..)
         def getter():
-          return getattr(self, "_get_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
+          return getattr(self, "_get_"+paramType+"_parameter")(paramSet, "->".join(sublist+[paramName]))
         # define setter
         def setter(val):
-          return getattr(self, "_set_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]), val)
+          return getattr(self, "_set_"+paramType+"_parameter")(paramSet, "->".join(sublist+[paramName]), val)
         return getter,setter
 
 
     def define_parameter_set(self, handler, paramSet, sublist=[]):
-        paramCount = self.get_num_parameters(paramSet, "?".join(sublist))
+        paramCount = self.get_num_parameters(paramSet, "->".join(sublist))
 
         allowed_types=["bool", "string", "double", "int"]
 
         for j in range(0, paramCount):
-            paramName = self.get_parameter_name(paramSet, "?".join(sublist) , j)
-            paramType = self._get_parameter_type(paramSet, "?".join(sublist + [paramName]))
+            paramName = self.get_parameter_name(paramSet, "->".join(sublist) , j)
+            paramType = self._get_parameter_type(paramSet, "->".join(sublist + [paramName]))
             if paramType=="ParameterList":
                 self.define_parameter_set(handler,paramSet, sublist + [paramName])
             else:
@@ -377,7 +377,7 @@ class iemic(InCodeComponentImplementation):
                 setattr(self, name_of_setter, setter)
 
                 # get default
-                default=getattr(self, "_get_default_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
+                default=getattr(self, "_get_default_"+paramType+"_parameter")(paramSet, "->".join(sublist+[paramName]))
                 # define parameter
                 handler.add_method_parameter(
                   name_of_getter,

--- a/src/omuse/community/iemic/interface.py
+++ b/src/omuse/community/iemic/interface.py
@@ -133,16 +133,28 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
         returns(name="")
 
     @remote_function
-    def get_parameter_type(set_name="", param_name=""):
+    def _get_parameter_type(set_name="", param_name=""):
         returns(name="")
 
-    @remote_function
-    def get_bool_parameter(set_name="", param_name=""):
-        returns(value=False)
+    def get_parameter_type(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_parameter_type(set_name, param_name)
 
     @remote_function
-    def set_bool_parameter(set_name="", param_name="", value=False):
+    def _get_bool_parameter(set_name="", param_name=""):
+        returns(value=False)
+
+    def get_bool_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_bool_parameter(set_name, param_name)
+
+    @remote_function
+    def _set_bool_parameter(set_name="", param_name="", value=False):
         returns()
+
+    def set_bool_parameter(self, param_name, val):
+        set_name, param_name = param_name.split("?", 1)
+        return self._set_bool_parameter(set_name, param_name, val)
 
     @remote_function
     def get_state_norm():
@@ -152,10 +164,13 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
     def _get_state_norm(src=0):
         returns(norm=0.)
 
-
     @remote_function
-    def get_default_bool_parameter(set_name="", param_name=""):
+    def _get_default_bool_parameter(set_name="", param_name=""):
         returns(value=False)
+
+    def get_default_bool_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_default_bool_parameter(set_name, param_name)
 
     #@remote_function
     #def get_char_parameter(set_name="", param_name=""):
@@ -170,40 +185,77 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
     #    returns(value='c')
 
     @remote_function
-    def get_double_parameter(set_name="", param_name=""):
+    def _get_double_parameter(set_name="", param_name=""):
         returns(value=0.)
 
-    @remote_function
-    def set_double_parameter(set_name="", param_name="", value=0.):
-        returns()
+    def get_double_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_double_parameter(set_name, param_name)
 
     @remote_function
-    def get_default_double_parameter(set_name="", param_name=""):
+    def _set_double_parameter(set_name="", param_name="", value=0.):
+        returns()
+
+    def set_double_parameter(self, param_name, val):
+        set_name, param_name = param_name.split("?", 1)
+        return self._set_double_parameter(set_name, param_name, val)
+
+    @remote_function
+    def _get_default_double_parameter(set_name="", param_name=""):
         returns(value=0.)
 
+    def get_default_double_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_default_double_parameter(set_name, param_name)
+
     @remote_function
-    def get_int_parameter(set_name="", param_name=""):
+    def _get_int_parameter(set_name="", param_name=""):
         returns(value=0)
 
-    @remote_function
-    def set_int_parameter(set_name="", param_name="", value=0):
-        returns()
+    def get_int_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_int_parameter(set_name, param_name)
 
     @remote_function
-    def get_default_int_parameter(set_name="", param_name=""):
+    def _set_int_parameter(set_name="", param_name="", value=0):
+        returns()
+
+    def set_int_parameter(self, param_name, val):
+        set_name, param_name = param_name.split("?", 1)
+        return self._set_int_parameter(set_name, param_name, val)
+
+    @remote_function
+    def _get_default_int_parameter(set_name="", param_name=""):
         returns(value=0)
 
-    @remote_function
-    def get_string_parameter(set_name="", param_name=""):
-        returns(value="")
+    def get_default_int_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_default_int_parameter(set_name, param_name)
 
     @remote_function
-    def set_string_parameter(set_name="", param_name="", value=""):
+    def _get_string_parameter(set_name="", param_name=""):
+        returns(value="")
+
+    def get_string_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        print(set_name, param_name)
+        return self._get_string_parameter(set_name, param_name)
+
+    @remote_function
+    def _set_string_parameter(set_name="", param_name="", value=""):
         returns()
 
+    def set_string_parameter(self, param_name, val):
+        set_name, param_name = param_name.split("?", 1)
+        return self._set_string_parameter(set_name, param_name, val)
+
     @remote_function
-    def get_default_string_parameter(set_name="", param_name=""):
+    def _get_default_string_parameter(set_name="", param_name=""):
         returns(value="")
+
+    def get_default_string_parameter(self, param_name):
+        set_name, param_name = param_name.split("?", 1)
+        return self._get_default_string_parameter(set_name, param_name)
 
     @remote_function(can_handle_array=True)
     def _new_state():
@@ -236,7 +288,7 @@ class iemicInterface(CodeInterface,CommonCodeInterface):
     @remote_function
     def _jacobian(src=0):
         returns()
-        
+
 
 class iemic(InCodeComponentImplementation):
     def __init__(self, **options):
@@ -247,7 +299,7 @@ class iemic(InCodeComponentImplementation):
         handler.add_transition('UNINITIALIZED', 'INITIALIZED', 'initialize')
         handler.add_transition('INITIALIZED', 'PARAM', 'commit_parameters')
         handler.add_transition('PARAM', 'PARAMC', 'commit_continuation_parameters')
-        
+
         for state in ["PARAM", "PARAMC"]:
             for method in ["get_u", "get_v", "get_w", "get_p", "get_t", "get_s",
                 "get_nrange", "get_mrange", "get_lrange", "_new_state"]:
@@ -259,10 +311,10 @@ class iemic(InCodeComponentImplementation):
 
     def _grid_range(self, **kwargs):
         return self.get_nrange()+self.get_mrange()+self.get_lrange()
-    
+
     def define_grids(self, handler):
         #~ code_generator.generate_grid_definitions(object)
-        
+
         # ocean dynamic variables p-grid: po, dpo_dt, vorticity
         handler.define_grid('grid',axes_names = ["lon", "lat"], grid_class=CartesianGrid)
         handler.set_grid_range('grid', '_grid_range')
@@ -284,21 +336,21 @@ class iemic(InCodeComponentImplementation):
     def _generate_parameter_setter_getters(self, paramSet, sublist, paramName, paramType):
         # define getter (closure or partial..)
         def getter():
-          return getattr(self, "get_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
-        # define setter 
+          return getattr(self, "_get_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
+        # define setter
         def setter(val):
-          return getattr(self, "set_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]), val)
+          return getattr(self, "_set_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]), val)
         return getter,setter
 
 
     def define_parameter_set(self, handler, paramSet, sublist=[]):
         paramCount = self.get_num_parameters(paramSet, "?".join(sublist))
-        
+
         allowed_types=["bool", "string", "double", "int"]
-        
+
         for j in range(0, paramCount):
             paramName = self.get_parameter_name(paramSet, "?".join(sublist) , j)
-            paramType = self.get_parameter_type(paramSet, "?".join(sublist + [paramName]))
+            paramType = self._get_parameter_type(paramSet, "?".join(sublist + [paramName]))
             if paramType=="ParameterList":
                 self.define_parameter_set(handler,paramSet, sublist + [paramName])
             else:
@@ -311,13 +363,13 @@ class iemic(InCodeComponentImplementation):
                 longname="__".join([paramSet] + sublist + [paramName])
                 longname=longname.replace(" ", "_").replace("-","_")
                 parameter_set_name="__".join([paramSet] + sublist)
-              
+
                 getter,setter=self._generate_parameter_setter_getters(paramSet, sublist, paramName, paramType)
 
                 # name of getter
-                name_of_getter="get_"+longname                
+                name_of_getter="_get_"+longname
                 # name of setter
-                name_of_setter="set_"+longname
+                name_of_setter="_set_"+longname
 
                 # add getter to interface
                 setattr(self, name_of_getter, getter)
@@ -325,7 +377,7 @@ class iemic(InCodeComponentImplementation):
                 setattr(self, name_of_setter, setter)
 
                 # get default
-                default=getattr(self, "get_default_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
+                default=getattr(self, "_get_default_"+paramType+"_parameter")(paramSet, "?".join(sublist+[paramName]))
                 # define parameter
                 handler.add_method_parameter(
                   name_of_getter,
@@ -335,10 +387,9 @@ class iemic(InCodeComponentImplementation):
                   default_value = default,
                   parameter_set=parameter_set_name.replace(" ", "_").replace("-","_")
                )
- 
+
 
     def define_parameters(self, handler):
-        
         paramSetCount = self.get_num_parameter_sets()
 
         for i in range(0, paramSetCount):
@@ -358,7 +409,7 @@ class iemic(InCodeComponentImplementation):
         result=self.new_state()
         self._solve(state._id, result._id)
         return result
-        
+
     def jacobian(self, state):
         self._jacobian(state._id)
 

--- a/src/omuse/community/iemic/paramset.cc
+++ b/src/omuse/community/iemic/paramset.cc
@@ -10,7 +10,7 @@ using namespace Teuchos;
 std::vector<std::string>
 split_name(const std::string& param_name)
 {
-    std::string delimiter = "?";
+    std::string delimiter = "->";
     std::string name(param_name);
     std::vector<std::string> name_parts;
 

--- a/src/omuse/community/iemic/test_iemic.py
+++ b/src/omuse/community/iemic/test_iemic.py
@@ -14,7 +14,7 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("continuation", "destination 0", 1.0)
+        err = instance.set_double_parameter("continuation?destination 0", 1.0)
         self.assertEqual(err,0)
 
         err = instance.commit_continuation_parameters()
@@ -39,7 +39,7 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("continuation", "destination 0", 1.0)
+        err = instance.set_double_parameter("continuation?destination 0", 1.0)
         self.assertEqual(err,0)
 
         err = instance.commit_continuation_parameters()
@@ -76,7 +76,7 @@ class iemicInterfaceTests(TestWithMPI):
 
     def paramHelper(self, instance, paramSet, n, sublist, param):
         print("!!>> |{0}|, |{1}|, |{2}|".format(paramSet, sublist,sublist+param)) 
-        paramType, err = instance.get_parameter_type(paramSet, sublist + param)
+        paramType, err = instance.get_parameter_type(paramSet + "?" + sublist + param)
         self.assertEqual(err,0)
 
         if paramType == "unknown":
@@ -85,6 +85,7 @@ class iemicInterfaceTests(TestWithMPI):
         print(("    " * n) + param + ": " + paramType, end=' ')
 
         param = sublist + param
+        complete_name = paramSet + "?" + param
 
         if paramType == "ParameterList":
             subParamCount, err = instance.get_num_parameters(paramSet, param)
@@ -98,26 +99,26 @@ class iemicInterfaceTests(TestWithMPI):
                 self.paramHelper(instance, paramSet, n+1, param + "?", subParamName)
 
         elif paramType == "bool":
-            val, err = instance.get_bool_parameter(paramSet, param)
+            val, err = instance.get_bool_parameter(complete_name)
             self.assertEqual(err,0)
 
-            default, err = instance.get_default_bool_parameter(paramSet, param)
+            default, err = instance.get_default_bool_parameter(complete_name)
             self.assertEqual(err,0)
             self.assertEqual(val, default)
 
             print(" (value: " + str(val) + ", default: " + str(default) + ")")
 
-            err = instance.set_bool_parameter(paramSet, param, val)
+            err = instance.set_bool_parameter(complete_name, val)
             self.assertEqual(err,0)
 
         elif paramType == "char":
             print()
 
         elif paramType == "double":
-            val, err = instance.get_double_parameter(paramSet, param)
+            val, err = instance.get_double_parameter(complete_name)
             self.assertEqual(err,0)
 
-            default, err = instance.get_default_double_parameter(paramSet, param)
+            default, err = instance.get_default_double_parameter(complete_name)
             self.assertEqual(err,0)
             if isnan(val):
                 self.assertEqual(isnan(val), isnan(default))
@@ -126,33 +127,33 @@ class iemicInterfaceTests(TestWithMPI):
 
             print(" (value: " + str(val) + ", default: " + str(default) + ")")
 
-            err = instance.set_double_parameter(paramSet, param, val)
+            err = instance.set_double_parameter(complete_name, val)
             self.assertEqual(err,0)
 
         elif paramType == "int":
-            val, err = instance.get_int_parameter(paramSet, param)
+            val, err = instance.get_int_parameter(complete_name)
             self.assertEqual(err,0)
 
-            default, err = instance.get_default_int_parameter(paramSet, param)
+            default, err = instance.get_default_int_parameter(complete_name)
             self.assertEqual(err,0)
             self.assertEqual(val, default)
 
             print(" (value: " + str(val) + ", default: " + str(default) + ")")
 
-            err = instance.set_int_parameter(paramSet, param, val)
+            err = instance.set_int_parameter(complete_name, val)
             self.assertEqual(err,0)
 
         elif paramType == "string":
-            val, err = instance.get_string_parameter(paramSet, param)
+            val, err = instance.get_string_parameter(complete_name)
             self.assertEqual(err,0)
 
-            default, err = instance.get_default_string_parameter(paramSet, param)
+            default, err = instance.get_default_string_parameter(complete_name)
             self.assertEqual(err,0)
             self.assertEqual(val, default)
 
             print(" (value: " + str(val) + ", default: " + str(default) + ")")
 
-            err = instance.set_string_parameter(paramSet, param, val)
+            err = instance.set_string_parameter(complete_name, val)
 
         else:
             assert 0, "unknow type!"
@@ -209,13 +210,13 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("ocean", "THCM?Global Bound xmin", 5.0)
+        err = instance.set_double_parameter("ocean?THCM?Global Bound xmin", 5.0)
         self.assertEqual(err,-1)
 
         err = instance.recommit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("ocean", "THCM?Starting Parameters?SPL1", 5.0)
+        err = instance.set_double_parameter("ocean?THCM?Starting Parameters?SPL1", 5.0)
         self.assertEqual(err,0)
 
         err = instance.recommit_parameters()

--- a/src/omuse/community/iemic/test_iemic.py
+++ b/src/omuse/community/iemic/test_iemic.py
@@ -14,7 +14,7 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("continuation?destination 0", 1.0)
+        err = instance.set_double_parameter("continuation->destination 0", 1.0)
         self.assertEqual(err,0)
 
         err = instance.commit_continuation_parameters()
@@ -39,7 +39,7 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("continuation?destination 0", 1.0)
+        err = instance.set_double_parameter("continuation->destination 0", 1.0)
         self.assertEqual(err,0)
 
         err = instance.commit_continuation_parameters()
@@ -76,7 +76,7 @@ class iemicInterfaceTests(TestWithMPI):
 
     def paramHelper(self, instance, paramSet, n, sublist, param):
         print("!!>> |{0}|, |{1}|, |{2}|".format(paramSet, sublist,sublist+param)) 
-        paramType, err = instance.get_parameter_type(paramSet + "?" + sublist + param)
+        paramType, err = instance.get_parameter_type(paramSet + "->" + sublist + param)
         self.assertEqual(err,0)
 
         if paramType == "unknown":
@@ -85,7 +85,7 @@ class iemicInterfaceTests(TestWithMPI):
         print(("    " * n) + param + ": " + paramType, end=' ')
 
         param = sublist + param
-        complete_name = paramSet + "?" + param
+        complete_name = paramSet + "->" + param
 
         if paramType == "ParameterList":
             subParamCount, err = instance.get_num_parameters(paramSet, param)
@@ -96,7 +96,7 @@ class iemicInterfaceTests(TestWithMPI):
             for i in range(0, subParamCount):
                 subParamName, err = instance.get_parameter_name(paramSet, param, i)
                 self.assertEqual(err,0)
-                self.paramHelper(instance, paramSet, n+1, param + "?", subParamName)
+                self.paramHelper(instance, paramSet, n+1, param + "->", subParamName)
 
         elif paramType == "bool":
             val, err = instance.get_bool_parameter(complete_name)
@@ -210,13 +210,13 @@ class iemicInterfaceTests(TestWithMPI):
         err = instance.commit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("ocean?THCM?Global Bound xmin", 5.0)
+        err = instance.set_double_parameter("ocean->THCM->Global Bound xmin", 5.0)
         self.assertEqual(err,-1)
 
         err = instance.recommit_parameters()
         self.assertEqual(err,0)
 
-        err = instance.set_double_parameter("ocean?THCM?Starting Parameters?SPL1", 5.0)
+        err = instance.set_double_parameter("ocean->THCM->Starting Parameters->SPL1", 5.0)
         self.assertEqual(err,0)
 
         err = instance.recommit_parameters()


### PR DESCRIPTION
Avoids the somewhat arbitrary "set name" vs "parameter name" distinction from the Python side. This will probably break #24, so that should probably be rebased + merged first.