### PR TITLE
Dales version tag

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -99,7 +99,7 @@ python3 -m pip install moviepy f90nml numpy scipy matplotlib nose h5py docutils 
 python3 -m pip install jupyter ipykernel
 mkdir /opt/notebooks
 
-export DOWNLOAD_CODES=latest
+export DOWNLOAD_CODES=1
 
 # work-around for DALES for finding netCDF, for Fedora and CentOS
 # where nf-config is broken and does not report the module path correctly

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -23,7 +23,7 @@ Get the OMUSE source code, install its Python dependencies and set up a developm
     git clone https://github.com/omuse-geoscience/omuse/
     cd omuse/
     pip install -e .
-    export DOWNLOAD_CODES=latest
+    export DOWNLOAD_CODES=1
 
 Build codes, select the ones needed::
   
@@ -46,3 +46,15 @@ Install Jupyter in the virtual environment, and make the virtual environment's P
 
 Alternatively, see :ref:`Singularity-section` for instructions for setting up and using a Singularity container with
 OMUSE and Jupyter.
+
+
+Code versions
+-------------
+
+For DALES, there are additional options controlling which version of the code is used:
+setting `DOWNLOAD_CODES=1` performs a shallow checkout of a single tag, while `DOWNLOAD_CODES="all"`
+clones the whole DALES git repository, which is useful for development.
+The environment variable `DALES_GIT_TAG` can be used to control which
+branch or version tag to check out.
+By default the variable points to a version tag in the DALES repository, which is tested to
+work with the current OMUSE. 

--- a/src/omuse/community/dales/Makefile
+++ b/src/omuse/community/dales/Makefile
@@ -14,8 +14,7 @@ MPIFC ?= mpif90
 # When using the previous fork of DALES, the following settings apply:
 # INCLUDEDIR = $(BUILDDIR)/src/ 
 #
-# DALES_GIT_DEFAULT_TAG ?= spifs_v1.0.0  # note: obsolete, does not work at the moment.
-# DALES_GIT_BRANCH ?= master
+# DALES_GIT_TAG ?= master
 # DALES_GIT_REPO ?= https://github.com/CloudResolvingClimateModeling/dales.git
 #
 # Also, when using the older fork, replace "make -j 4" by "make" in the "dales:" rule below,
@@ -61,20 +60,16 @@ ifeq ($(DEBUG), yes)
     CMAKE_BLD = Debug
 endif
 
-# DOWNLOAD_CODES=all will checkout entire repo with ssh, intended for developers of the components.
-# DOWNLOAD_CODES=latest will (shallow) checkout latest revision only
-# DOWNLOAD_CODES=<anything else> will (shallow) checkout release tag spifs_v1.0.0
+# DOWNLOAD_CODES=all will clone the entire repo and check out $DALES_GIT_TAG, intended for developers of the components.
+# DOWNLOAD_CODES=<anything else> will (shallow) checkout $DALES_GIT_TAG.
+#   $DALES_GIT_TAG defaults to the release tag "4.3-rc.1"
 
-DALES_GIT_DEFAULT_TAG ?= spifs_v1.0.0  # obsolete - move to 4.3 when released
-DALES_GIT_BRANCH ?= to4.3_Fredrik      # change to master when 4.3 is released
+DALES_GIT_TAG ?= 4.3-rc.1
 DALES_GIT_REPO ?= https://github.com/dalesteam/dales.git
-GIT_CLONE_CMD = git clone -b $(DALES_GIT_DEFAULT_TAG) --single-branch --depth=1
+GIT_CLONE_CMD = git clone -b $(DALES_GIT_TAG) --single-branch --depth=1
 
 ifeq ($(DOWNLOAD_CODES), all)
-    GIT_CLONE_CMD = git clone -b $(DALES_GIT_BRANCH)
-endif
-ifeq ($(DOWNLOAD_CODES), latest)
-    GIT_CLONE_CMD = git clone --depth=1 -b $(DALES_GIT_BRANCH)
+    GIT_CLONE_CMD = git clone -b $(DALES_GIT_TAG)
 endif
 
 all: dales dales_worker test/run_dales data


### PR DESCRIPTION
Pin the default DALES version: when installing DALES, check out the tag '4.3-rc.1' by default. The tag/branch/commit can be overridden by setting the environment variable DALES_GIT_TAG.