### PR TITLE
iemic: Don't link to mrilucpp libraries.

### DIFF
--- a/src/omuse/community/iemic/Makefile
+++ b/src/omuse/community/iemic/Makefile
@@ -25,7 +25,7 @@ CODE_GENERATOR:=amusifier
 MPICXX   ?= mpicxx
 
 CFLAGS   += -Wall -g
-LIBS:=iemic coupledmodel globaldefs utils ifpack_mrilu mrilucpp
+LIBS:=iemic coupledmodel globaldefs utils
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)


### PR DESCRIPTION
We don't build these as shared libraries anymore, because that fixes out of source builds on my laptop.