### PR TITLE
iemic: Call preProcess() every time a parameter is set.

### DIFF
--- a/src/omuse/community/iemic/interface.cc
+++ b/src/omuse/community/iemic/interface.cc
@@ -397,6 +397,7 @@ int32_t recommit_parameters()
     try {
         ocean->setParameters(ocean_params.updates());
         ocean_params.update_committed_parameters(ocean->getParameters());
+        ocean->preProcess();
 
         return 0;
     } catch (const std::exception& exc) {


### PR DESCRIPTION
This makes sure we recompute the preconditioner after changing a parameter. It would be better to make this optional, but at least this is much better than never recomputing it.